### PR TITLE
Add Python extcap script for use with Linux.

### DIFF
--- a/Wireshark/zigbee_dongle_json_sniffer
+++ b/Wireshark/zigbee_dongle_json_sniffer
@@ -87,21 +87,24 @@ def capture(fifo, device, baud, channel_filter=None):
 
         packet = bytes.fromhex(data["S"])
         channel_num = data.get("C", 11)
-        freq_mhz = (2405 + (channel_num - 11) * 5)*1e3
+        freq_khz = channel_to_freq_mhz(channel_num)*1e3
         rssi_signed = data.get("R", -100)
         lqi = data.get("Q", 255) & 0xff
 
         # https://gitlab.com/exegin/ieee802-15-4-tap/-/blob/master/IEEE%20802.15.4%20TAP%20Link%20Type%20Specification.pdf
+        # name = (code, length, type)
         # FCS_TYPE = (0, 1, 'B')
+        # CHANNEL_ASSIGNMENT =  = (3, 3, ('H', 'B'))
         # RSS = (1, 4, 'f')
         # LQI = (10, 1, 'B')
         # CHANNEL_FREQUENCY = (11, 4, 'f')
-        fcs_tlv = struct.pack('<HHBxxx', 0, 1, 0)
+        fcs_tlv = struct.pack('<HHBxxx', 0, 1, 1)
+        channel_tlv = struct.pack('<HHHBx', 3, 3, channel_num, 0)
         rssi_tlv = struct.pack('<HHf', 1, 4, rssi_signed)
         lqi_tlv = struct.pack('<HHBxxx', 10, 1, lqi)
-        channel_tlv = struct.pack('<HHf', 11, 4, freq_mhz)
+        channel_freq_tlv = struct.pack('<HHf', 11, 4, freq_khz)
 
-        tap_body = channel_tlv + rssi_tlv + lqi_tlv + fcs_tlv
+        tap_body = fcs_tlv + channel_tlv + rssi_tlv + lqi_tlv + channel_freq_tlv
         tap_header = struct.pack('<HH', 0, 4 + len(tap_body))  # version, total header length
 
         incl_len = len(tap_header + tap_body + packet)
@@ -110,13 +113,26 @@ def capture(fifo, device, baud, channel_filter=None):
         packet_record_hdr = struct.pack('<IIII',
                     ts_sec, ts_usec, incl_len, orig_len)
 
-        print(f'READ: {incl_len} {orig_len} {ts_sec} {ts_usec} {channel_num} {freq_mhz} {rssi_signed} {lqi}')
+        print(f'READ: incl_len={incl_len} orig_len={orig_len} ts_sec={ts_sec} '
+          f'ts_usec={ts_usec} channel_num={channel_num} freq_khz={freq_khz} '
+          f'rssi_signed={rssi_signed} lqi={lqi}')
 
         f.write(packet_record_hdr + tap_header + tap_body + packet)
 
       except Exception as e:
         print(f'BAD LINE: {e}')
 
+
+def channel_to_freq_mhz(channel):
+    ''' Convert IEEE 802.15.4 channel page 0 number to frequency in MHz. '''
+    if channel == 0:  # 868 MHz band
+      return 868.3
+    elif 1 <= channel <= 10: # 915 MHz band
+      return 906 + 2 * channel
+    elif 11 <= channel <= 26: # 2.4 GHz band
+      return 2405 + 5 * (channel - 11)
+    else:
+      return -1
 
 if __name__ == '__main__':
   main()

--- a/Wireshark/zigbee_dongle_json_sniffer
+++ b/Wireshark/zigbee_dongle_json_sniffer
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import sys, json, time, serial, struct, argparse
+
+
+INTERFACE="zb_dongle_json_sniffer"
+VERSION="0.1"
+DLT=283  # DLT_IEEE802_15_4_TAP
+PCAP_MAGIC = 0xA1B2C3D4
+PCAP_VERSION_MAJOR = 2
+PCAP_VERSION_MINOR = 4
+THISZONE = 0        # GMT offset
+SIGFIGS = 0         # Timestamp accuracy
+SNAPLEN = 1500      # Max capture size
+
+
+def main(args=None):
+  args = parseargs(args or sys.argv[1:])
+  if args.extcap_interfaces:
+    print("extcap {version=%s}" % (VERSION,))
+    print("interface {value=%s}{display=Zigbee JSON Sniffer}" % (INTERFACE,))
+  elif args.extcap_dlts:
+    print("dlt {number=%s}{name=IEEE802_15_4_TAP}{display=IEEE 802.15.4 TAP}" % (DLT,))
+  elif args.extcap_config:
+    print("arg {number=0}{call=--device}{display=Serial device}{type=string}{default=/dev/ttyUSB0}{tooltip=Serial port of sniffer dongle}")
+    print("arg {number=1}{call=--baud}{display=Baud rate}{type=unsigned}{default=1000000}{tooltip=Baud rate (usually 1000000)}")
+    print("arg {number=2}{call=--channel}{display=Channel}{type=selector}{tooltip=Optional fixed channel filter}")
+    print("value {arg=2}{value=11}{display=11}")
+    print("value {arg=2}{value=12}{display=12}")
+  elif args.capture:
+    capture(args.fifo, device=args.device, baud=args.baud, channel_filter=args.channel)
+
+
+def parseargs(args: list[str]):
+  parser = argparse.ArgumentParser(
+    description='Zigbee JSON Sniffer'
+  )
+  group = parser.add_mutually_exclusive_group(required=True)
+  group.add_argument('--extcap-interfaces', default=False, action='store_true')
+  group.add_argument('--extcap-dlts', default=False, action='store_true')
+  group.add_argument('--extcap-config', default=False, action='store_true')
+  parser.add_argument('--extcap-interface', default='', type=str)
+  # parser.add_arguemnt('--extcap-version=4.4', default='', type=str)
+  group.add_argument('--capture', default=False, action='store_true')
+  capture_group = parser.add_argument_group()
+  capture_group.add_argument('--device', type=str, default="/dev/ttyUSB0")
+  capture_group.add_argument('--baud', type=str, default="1000000")
+  capture_group.add_argument('--channel', type=int, default=None)
+  capture_group.add_argument('--fifo', type=str)
+  args, _unknown = parser.parse_known_args(args)
+  if args.capture and not args.fifo:
+    parser.error("--fifo is required with --capture")
+  return args
+
+
+def capture(fifo, device, baud, channel_filter=None):
+  print(f'DEV={device} BAUD={baud} CHAN={channel_filter} FIFO={fifo}')
+
+  ser = serial.Serial(device, baud, timeout=1)
+
+  with open(fifo, 'wb', 0) as f:
+    header = struct.pack('<IHHIIII',
+      PCAP_MAGIC,
+      PCAP_VERSION_MAJOR,
+      PCAP_VERSION_MINOR,
+      THISZONE,
+      SIGFIGS,
+      SNAPLEN,
+      DLT)
+    f.write(header)
+
+    while True:
+      line = ser.readline().strip()
+      print(f'READ: {line}')
+      if not line:
+        continue
+      try:
+        data = json.loads(line)
+
+        # Optional channel filter
+        if channel_filter and data.get("C") != int(channel_filter):
+          continue
+
+        # Timestamp
+        ts = time.time()
+        ts_sec = int(ts)
+        ts_usec = int((ts - ts_sec) * 1_000_000)
+
+        packet = bytes.fromhex(data["S"])
+        channel_num = data.get("C", 11)
+        freq_mhz = (2405 + (channel_num - 11) * 5)*1e3
+        rssi_signed = data.get("R", -100)
+        lqi = data.get("Q", 255) & 0xff
+
+        # https://gitlab.com/exegin/ieee802-15-4-tap/-/blob/master/IEEE%20802.15.4%20TAP%20Link%20Type%20Specification.pdf
+        # FCS_TYPE = (0, 1, 'B')
+        # RSS = (1, 4, 'f')
+        # LQI = (10, 1, 'B')
+        # CHANNEL_FREQUENCY = (11, 4, 'f')
+        fcs_tlv = struct.pack('<HHBxxx', 0, 1, 0)
+        rssi_tlv = struct.pack('<HHf', 1, 4, rssi_signed)
+        lqi_tlv = struct.pack('<HHBxxx', 10, 1, lqi)
+        channel_tlv = struct.pack('<HHf', 11, 4, freq_mhz)
+
+        tap_body = channel_tlv + rssi_tlv + lqi_tlv + fcs_tlv
+        tap_header = struct.pack('<HH', 0, 4 + len(tap_body))  # version, total header length
+
+        incl_len = len(tap_header + tap_body + packet)
+        orig_len = incl_len
+
+        packet_record_hdr = struct.pack('<IIII',
+                    ts_sec, ts_usec, incl_len, orig_len)
+
+        print(f'READ: {incl_len} {orig_len} {ts_sec} {ts_usec} {channel_num} {freq_mhz} {rssi_signed} {lqi}')
+
+        f.write(packet_record_hdr + tap_header + tap_body + packet)
+
+      except Exception as e:
+        print(f'BAD LINE: {e}')
+
+
+if __name__ == '__main__':
+  main()

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
   - [What's next](#whats-next)
 
 
-This reposiroty contains firmware to allow capturing 802.15.4 packets with a USB SONOFF Zigbee 3.0 DONGLE Plus-E.
+This repository contains firmware to allow capturing 802.15.4 packets with a USB SONOFF Zigbee 3.0 DONGLE Plus-E.
 
 The USB dongle once reflashed will capture 802.15.4 traffic (Zigbee, 6lowpan/Thread) and send a frame in JSON format on USB Serial COM port to the host computer.
 
@@ -41,18 +41,18 @@ The file Sniffer_802.15.4_SONOFF_USB_Dongle_Plus_E.gbl must be used when perform
 Wireshark needs a converter to understand and display correctly the packets captured by the USB dongle.
 A wireshark converter is called an Extcap (short for EXTernal CAPture).
 
-To provide Wireshark with the needed Extcap, copy the file found in this repo under folder /Wireshrak/Extcap_802.15.4.exe to wireshark extcap folder.
-To locate the wireshark extcap folder, start wireshark, click on Help->About wireshark, select TAB named "folders", locate the
-Global Extcap path
-or
-Personal Extcap path
+Extcap files can be found in this repo under folder /Wireshark/:
 
-The file Extcap_802.15.4.exe needs to be copied in only one of the two folders.
+  - Windows: Extcap_802.15.4.exe; Compatible with Windows 10 and up.
+  - Python/Linux: zigbee_dongle_json_sniffer; Requires Python 3.9+ interpreter and pyserial.
+
+To provide Wireshark with the needed Extcap, copy the appropriate file to the wireshark extcap folder. To locate the wireshark extcap folder, start wireshark, click on Help->About wireshark, select TAB named "folders", locate the "Global Extcap path" or "Personal Extcap path".
+
+The extcap file  needs to be copied in only one of the two folders.
+
 Close wireshark once the copy is done, the Extcap will be loaded the next time wireshark is started.
 
 If you are interested in wireshark Extcap, you can refer to wireshark doc [8.2. Adding Capture Interfaces And Log Sources Using Extcap](https://www.wireshark.org/docs/wsdg_html_chunked/ChCaptureExtcap.html).
-The Wireshark Extcap plugin provided in this repo is compatible with computer running Windows 10 and up.
-
 
 ## How to record packets
 
@@ -73,7 +73,7 @@ Capture should start!
 ## Wireshark color scheme for ZigBee
 
 By default Wireshark presents ZigBee packets in black text on white background.
-The default color schem can make it difficult to quickly identify packet when analyzing ZigBee packets.
+The default color scheme can make it difficult to quickly identify packet when analyzing ZigBee packets.
 This repo provides a color scheme for Wireshark (file Wireshark\zigbee_color_scheme) well suited for ZigBee packet analysis.
 ZCL and APS packets are in green
 ZDP/ZDO packets are colored red
@@ -120,7 +120,7 @@ Example, C = channel:
 {"C":11}
 ```
 
-when sent to the usb dongle will select channel 11, can be used at anytime.
+when sent to the USB dongle will select channel 11, can be used at anytime.
 
 ## How to compile
 
@@ -152,4 +152,3 @@ Here are some wish list items that I have in mind:
 - Improve BSP when porting evolves
 - Provide a .gbl having the factory image for user desiring to return to the factory firmware
 - keep having fun...
-

--- a/readme.md
+++ b/readme.md
@@ -48,9 +48,21 @@ Extcap files can be found in this repo under folder /Wireshark/:
 
 To provide Wireshark with the needed Extcap, copy the appropriate file to the wireshark extcap folder. To locate the wireshark extcap folder, start wireshark, click on Help->About wireshark, select TAB named "folders", locate the "Global Extcap path" or "Personal Extcap path".
 
-The extcap file  needs to be copied in only one of the two folders.
+The extcap file needs to be copied in only one of the two folders.
 
 Close wireshark once the copy is done, the Extcap will be loaded the next time wireshark is started.
+
+On Linux additional setup may be required:
+
+```
+# Ensure the script has execution permissions set:
+chmod +x zigbee_dongle_json_sniffer
+# Add yourself to the wireshark group (optional if you want to run Wireshark as non-root user):
+sudo usermod $USER -a -G wireshark
+# Make sure you have read permissions for the dongle. Usually this can be done my adding yourself to the dialout group:
+sudo usermod $USER -a -G dialout
+# Logout and back in for user group changes to take effect.
+```
 
 If you are interested in wireshark Extcap, you can refer to wireshark doc [8.2. Adding Capture Interfaces And Log Sources Using Extcap](https://www.wireshark.org/docs/wsdg_html_chunked/ChCaptureExtcap.html).
 


### PR DESCRIPTION
Hey @ErkSponge. Wrote this script so I could use your firmware with Wireshark on Linux. Tested on Debian Trixie, wireshark 4.4.7-1.